### PR TITLE
Persist session and cookies set on result

### DIFF
--- a/play-v29/src/main/scala/play.filters.brotli/BrotliFilter.scala
+++ b/play-v29/src/main/scala/play.filters.brotli/BrotliFilter.scala
@@ -89,13 +89,13 @@ class BrotliFilter @Inject() (config: BrotliFilterConfig)(implicit mat: Material
       result.body match {
 
         case HttpEntity.Strict(data, contentType) =>
-          Future.successful(Result(header, compressStrictEntity(data, contentType)))
+          Future.successful(result.copy(header = header, body = compressStrictEntity(data, contentType)))
 
 
         case entity @ HttpEntity.Streamed(_, Some(contentLength), contentType) if contentLength <= config.chunkedThreshold =>
           // It's below the chunked threshold, so buffer then compress and send
           entity.consumeData.map { data =>
-            Result(header, compressStrictEntity(data, contentType))
+            result.copy(header = header, body = compressStrictEntity(data, contentType))
           }
 
         case HttpEntity.Streamed(data, _, contentType) if request.version == HttpProtocol.HTTP_1_0 => 
@@ -109,7 +109,7 @@ class BrotliFilter @Inject() (config: BrotliFilterConfig)(implicit mat: Material
         case HttpEntity.Streamed(data, _, contentType) =>
           // It's above the chunked threshold, compress through the brotli flow, and send as chunked
           val compressed = data.via(createBrotliFlow).map(d => HttpChunk.Chunk(d))
-          Future.successful(Result(header, HttpEntity.Chunked(compressed, contentType)))
+          Future.successful(result.copy(header = header, body = HttpEntity.Chunked(compressed, contentType)))
 
         case HttpEntity.Chunked(chunks, contentType) =>
           val wrappedFlow = Flow.fromGraph(GraphDSL.create[FlowShape[HttpChunk, HttpChunk]]() { implicit builder =>
@@ -138,7 +138,7 @@ class BrotliFilter @Inject() (config: BrotliFilterConfig)(implicit mat: Material
 
             new FlowShape(broadcast.in, concat.out)
           })
-          Future.successful(Result(header, HttpEntity.Chunked(chunks via wrappedFlow, contentType)))
+          Future.successful(result.copy(header = header, body = HttpEntity.Chunked(chunks via wrappedFlow, contentType)))
       }
     } else {
       Future.successful(result)

--- a/play-v29/src/test/scala/play.filters.brotli/BrotliFilterSpec.scala
+++ b/play-v29/src/test/scala/play.filters.brotli/BrotliFilterSpec.scala
@@ -27,6 +27,7 @@ import scala.util.Random
 import org.specs2.matcher.{DataTables, MatchResult}
 
 import com.aayushatharva.brotli4j.decoder.BrotliInputStream;
+import play.api.mvc.Cookie
 
 object BrotliFilterSpec extends PlaySpecification with DataTables {
 
@@ -140,6 +141,18 @@ object BrotliFilterSpec extends PlaySpecification with DataTables {
       val result = makeBrotliRequest(app)
       checkCompressed(result)
       header(SERVER, result) must beSome("Play")
+    }
+
+    "preserve original cookies" in withApplication(Ok("hello").withCookies(Cookie("foo", "bar"))) { implicit app =>
+      val result = makeBrotliRequest(app)
+      checkCompressed(result)
+      cookies(result).get("foo") must beSome(Cookie("foo", "bar"))
+    }
+
+    "preserve original session" in withApplication(Ok("hello").withSession("foo" -> "bar")) { implicit app =>
+      val result = makeBrotliRequest(app)
+      checkCompressed(result)
+      session(result).get("foo") must beSome("bar")
     }
 
     "preserve original Vary header values" in withApplication(Ok("hello").withHeaders(VARY -> "original")) { implicit app =>

--- a/play-v30/src/main/scala/play.filters.brotli/BrotliFilter.scala
+++ b/play-v30/src/main/scala/play.filters.brotli/BrotliFilter.scala
@@ -89,13 +89,13 @@ class BrotliFilter @Inject() (config: BrotliFilterConfig)(implicit mat: Material
       result.body match {
 
         case HttpEntity.Strict(data, contentType) =>
-          Future.successful(Result(header, compressStrictEntity(data, contentType)))
+          Future.successful(result.copy(header = header, body = compressStrictEntity(data, contentType)))
 
 
         case entity @ HttpEntity.Streamed(_, Some(contentLength), contentType) if contentLength <= config.chunkedThreshold =>
           // It's below the chunked threshold, so buffer then compress and send
           entity.consumeData.map { data =>
-            Result(header, compressStrictEntity(data, contentType))
+            result.copy(header = header, body = compressStrictEntity(data, contentType))
           }
 
         case HttpEntity.Streamed(data, _, contentType) if request.version == HttpProtocol.HTTP_1_0 =>
@@ -109,7 +109,7 @@ class BrotliFilter @Inject() (config: BrotliFilterConfig)(implicit mat: Material
         case HttpEntity.Streamed(data, _, contentType) =>
           // It's above the chunked threshold, compress through the brotli flow, and send as chunked
           val compressed = data.via(createBrotliFlow).map(d => HttpChunk.Chunk(d))
-          Future.successful(Result(header, HttpEntity.Chunked(compressed, contentType)))
+          Future.successful(result.copy(header = header, body = HttpEntity.Chunked(compressed, contentType)))
 
         case HttpEntity.Chunked(chunks, contentType) =>
           val wrappedFlow = Flow.fromGraph(GraphDSL.create[FlowShape[HttpChunk, HttpChunk]]() { implicit builder =>
@@ -138,7 +138,7 @@ class BrotliFilter @Inject() (config: BrotliFilterConfig)(implicit mat: Material
 
             new FlowShape(broadcast.in, concat.out)
           })
-          Future.successful(Result(header, HttpEntity.Chunked(chunks via wrappedFlow, contentType)))
+          Future.successful(result.copy(header = header, body = HttpEntity.Chunked(chunks via wrappedFlow, contentType)))
       }
     } else {
       Future.successful(result)

--- a/play-v30/src/test/scala/play.filters.brotli/BrotliFilterSpec.scala
+++ b/play-v30/src/test/scala/play.filters.brotli/BrotliFilterSpec.scala
@@ -27,6 +27,7 @@ import scala.util.Random
 import org.specs2.matcher.{DataTables, MatchResult}
 
 import com.aayushatharva.brotli4j.decoder.BrotliInputStream;
+import play.api.mvc.Cookie
 
 object BrotliFilterSpec extends PlaySpecification with DataTables {
 
@@ -140,6 +141,18 @@ object BrotliFilterSpec extends PlaySpecification with DataTables {
       val result = makeBrotliRequest(app)
       checkCompressed(result)
       header(SERVER, result) must beSome("Play")
+    }
+
+    "preserve original cookies" in withApplication(Ok("hello").withCookies(Cookie("foo", "bar"))) { implicit app =>
+      val result = makeBrotliRequest(app)
+      checkCompressed(result)
+      cookies(result).get("foo") must beSome(Cookie("foo", "bar"))
+    }
+
+    "preserve original session" in withApplication(Ok("hello").withSession("foo" -> "bar")) { implicit app =>
+      val result = makeBrotliRequest(app)
+      checkCompressed(result)
+      session(result).get("foo") must beSome("bar")
     }
 
     "preserve original Vary header values" in withApplication(Ok("hello").withHeaders(VARY -> "original")) { implicit app =>


### PR DESCRIPTION
Currently, in most code paths the filter constructs a new Result object with updated body and headers, which means that any new session or cookies previously set on the result will be dropped. The impact of this can currently be seen on the CV redact tool, which cannot pass CSRF checks because the session is never sent to the user's browser, so the CSRF token sent with the submission cannot be verified.

Instead, copy the Result to insert the updated headers and body without dropping other values set on the Result.