### PR TITLE
Updates dependencies  november 2024

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -126,9 +126,9 @@ lazy val `play-v28` = project
     description := "A brotli filter module for Play 2.8",
     crossScalaVersions := Seq(Scala212, Scala213),
     libraryDependencies ++= Seq(
-      "com.typesafe.play" %% "play" % "2.8.21" % Provided,
-      "com.typesafe.play" %% "filters-helpers" % "2.8.21" % Test,
-      "com.typesafe.play" %% "play-specs2" % "2.8.21" % Test,
+      "com.typesafe.play" %% "play" % "2.8.22" % Provided,
+      "com.typesafe.play" %% "filters-helpers" % "2.8.22" % Test,
+      "com.typesafe.play" %% "play-specs2" % "2.8.22" % Test,
       "ch.qos.logback" % "logback-classic" % "1.4.14"  % Test,
       /* override guice version below to fix reflection issue see https://github.com/google/guice/issues/1133 */
       "com.google.inject" % "guice" % "6.0.0" % Test,

--- a/build.sbt
+++ b/build.sbt
@@ -3,9 +3,9 @@ import sbtrelease.ReleaseStateTransformations._
 resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/"
 
 
-val Scala212 = "2.12.19"
-val Scala213 = "2.13.14"
-val Scala3 = "3.3.3"
+val Scala212 = "2.12.20"
+val Scala213 = "2.13.15"
+val Scala3 = "3.3.4"
 
 
 ThisBuild / scalaVersion := Scala213

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.1
+sbt.version=1.10.4

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.17.0"
+ThisBuild / version := "0.17.1"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.16.2-SNAPSHOT"
+ThisBuild / version := "0.17.0"


### PR DESCRIPTION
## What does this change?

- Update Scala to [`2.12.20`](https://github.com/scala/scala/releases/tag/v2.12.20),[`2.13.15`](https://github.com/scala/scala/releases/tag/v2.13.15),[`3.3.4`](https://github.com/scala/scala3/releases/tag/3.3.4) 
- Update SBT to [`1.10.4`](https://github.com/sbt/sbt/releases/tag/v1.10.4)
- Update play framework to [`2.8.22`](https://github.com/playframework/playframework/milestone/130?closed=1)